### PR TITLE
Enum Risco

### DIFF
--- a/src/main/java/com/softwave/clean_arch_softwave/entities/Risco.java
+++ b/src/main/java/com/softwave/clean_arch_softwave/entities/Risco.java
@@ -1,0 +1,35 @@
+package com.softwave.clean_arch_softwave.entities;
+
+public enum Risco {
+    BAIXO(3, "Contato automático por e-mail"),
+    MEDIO(2, "Análise manual em até 48h"),
+    ALTO(1, "Contato telefônico em até 24h + análise crítica");
+
+    private final int prioridade;
+    private final String estrategiaContato;
+
+    Risco(int prioridade, String estrategiaContato) {
+        this.prioridade = prioridade;
+        this.estrategiaContato = estrategiaContato;
+    }
+
+    public int getPrioridade() {
+        return prioridade;
+    }
+
+    public String getEstrategiaContato() {
+        return estrategiaContato;
+    }
+
+    public static Risco avaliarRisco(double renda, int idade) {
+        if (renda > 6000 && idade > 30) {
+            return BAIXO;
+        } else if (renda < 3000) {
+            return ALTO;
+        } else if ((renda >= 3000 && renda <= 6000) || idade <= 30) {
+            return MEDIO;
+        } else {
+            return ALTO;
+        }
+    }
+}

--- a/src/main/java/com/softwave/clean_arch_softwave/entities/readme.md
+++ b/src/main/java/com/softwave/clean_arch_softwave/entities/readme.md
@@ -1,1 +1,0 @@
-Entidades do Domínio


### PR DESCRIPTION
This pull request introduces a new domain entity to the project by adding the `Risco` enum, which encapsulates risk assessment logic and associated contact strategies. Additionally, a minor documentation change was made.

**Domain logic enhancements:**

* Added the `Risco` enum in `Risco.java`, which defines three risk levels (`BAIXO`, `MEDIO`, `ALTO`) with associated priorities and contact strategies, and includes a static method `avaliarRisco` to determine risk based on `renda` (income) and `idade` (age).

**Documentation:**

* Removed the line "Entidades do Domínio" from the `entities/readme.md` file.